### PR TITLE
Use compare-and-swap when modifying secret info

### DIFF
--- a/Network/QUIC/Connection/Crypto.hs
+++ b/Network/QUIC/Connection/Crypto.hs
@@ -100,9 +100,8 @@ getPeerParameters :: Connection -> IO Parameters
 getPeerParameters Connection{..} = readIORef peerParams
 
 setPeerParameters :: Connection -> ParametersList -> IO ()
-setPeerParameters Connection{..} plist = do
-    def <- readIORef peerParams
-    writeIORef peerParams $ updateParameters def plist
+setPeerParameters Connection{..} plist =
+    modifyIORef peerParams $ \def -> updateParameters def plist
 
 ----------------------------------------------------------------
 

--- a/Network/QUIC/Connection/Crypto.hs
+++ b/Network/QUIC/Connection/Crypto.hs
@@ -77,13 +77,13 @@ getCipher Connection{..} _ = do
 
 setEarlySecretInfo :: Connection -> Maybe EarlySecretInfo -> IO ()
 setEarlySecretInfo _ Nothing = return ()
-setEarlySecretInfo Connection{..} (Just info) = writeIORef elySecInfo info
+setEarlySecretInfo Connection{..} (Just info) = atomicWriteIORef elySecInfo info
 
 setHandshakeSecretInfo :: Connection -> HandshakeSecretInfo -> IO ()
-setHandshakeSecretInfo Connection{..} info = writeIORef hndSecInfo info
+setHandshakeSecretInfo Connection{..} = atomicWriteIORef hndSecInfo
 
 setApplicationSecretInfo :: Connection -> ApplicationSecretInfo -> IO ()
-setApplicationSecretInfo Connection{..} info = writeIORef appSecInfo info
+setApplicationSecretInfo Connection{..} = atomicWriteIORef appSecInfo
 
 getEarlySecretInfo :: Connection -> IO EarlySecretInfo
 getEarlySecretInfo Connection{..} = readIORef elySecInfo
@@ -192,6 +192,6 @@ xApplicationSecret Connection{..} = do
 dropSecrets :: Connection -> IO ()
 dropSecrets Connection{..} = do
     writeIORef iniSecrets defaultTrafficSecrets
-    writeIORef elySecInfo (EarlySecretInfo defaultCipher (ClientTrafficSecret ""))
-    HandshakeSecretInfo cipher _ <- readIORef hndSecInfo
-    writeIORef hndSecInfo (HandshakeSecretInfo cipher defaultTrafficSecrets)
+    atomicWriteIORef elySecInfo (EarlySecretInfo defaultCipher (ClientTrafficSecret ""))
+    atomicModifyIORef' hndSecInfo $ \(HandshakeSecretInfo cipher _) ->
+        (HandshakeSecretInfo cipher defaultTrafficSecrets, ())


### PR DESCRIPTION
I was looking how IORefs modified by TLS threads are used by quic.  In the Dispatcher threads sometimes decryptCrypt is called, so this reads the secret info IORefs with getCipher and getRxSecret.  I don't see any synchronization here, so think it's best to use atomic modify.