### PR TITLE
Making fire safer

### DIFF
--- a/Network/QUIC.hs
+++ b/Network/QUIC.hs
@@ -7,7 +7,6 @@ module Network.QUIC (
   , runQUICServer
   , stopQUICServer
   , Connection
-  , isConnectionOpen
   , abortConnection
   -- * Stream
   , Stream

--- a/Network/QUIC/Client.hs
+++ b/Network/QUIC/Client.hs
@@ -25,7 +25,6 @@ import Network.QUIC.Parameters
 import Network.QUIC.Qlog
 import Network.QUIC.Recovery
 import Network.QUIC.Socket
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 -- | readerClient dies when the socket is closed.
@@ -140,4 +139,4 @@ rebind conn microseconds = do
     v <- getVersion conn
     mytid <- myThreadId
     void $ forkIO $ readerClient mytid [v] s1 q conn -- versions are dummy
-    fire microseconds $ shutdownAndClose s0
+    fire conn microseconds $ shutdownAndClose s0

--- a/Network/QUIC/Connection.hs
+++ b/Network/QUIC/Connection.hs
@@ -78,7 +78,6 @@ module Network.QUIC.Connection (
   , setConnection0RTTReady
   , setConnection1RTTReady
   , setConnectionEstablished
-  , setConnectionClosing
   , setCloseSent
   , setCloseReceived
   , isCloseSent
@@ -166,12 +165,11 @@ module Network.QUIC.Connection (
   , Input(..)
   , Crypto(..)
   , Output(..)
-  , connAlive
+  , setDead
   -- In this module
   , sendErrorCCFrame
   , sendCCFrameAndWait
   , sendCCFrameAndBreak
-  , isConnectionOpen
   , sendFrames
   , abortConnection
   ) where
@@ -219,10 +217,6 @@ sendCCFrameAndBreak :: Connection -> EncryptionLevel -> TransportError -> ShortB
 sendCCFrameAndBreak conn lvl err desc ftyp = do
     sendErrorCCFrame conn lvl err desc ftyp
     E.throwIO BreakForever
-
--- | Checking if a connection is open.
-isConnectionOpen :: Connection -> IO Bool
-isConnectionOpen = isConnOpen
 
 -- | Closing a connection with an error code.
 --   A specified error code is sent to the peer and

--- a/Network/QUIC/Connection.hs
+++ b/Network/QUIC/Connection.hs
@@ -153,6 +153,12 @@ module Network.QUIC.Connection (
   , getCertificateChain
   , setSockAddrs
   , getSockAddrs
+  -- Timeout
+  , timeouter
+  , timeout
+  , fire
+  , cfire
+  , delay
   -- Types
   , connHooks
   , Hooks(..)
@@ -182,10 +188,10 @@ import Network.QUIC.Connection.Role
 import Network.QUIC.Connection.State
 import Network.QUIC.Connection.Stream
 import Network.QUIC.Connection.StreamTable
+import Network.QUIC.Connection.Timeout
 import Network.QUIC.Connection.Types
 import Network.QUIC.Connector
 import Network.QUIC.Imports
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 sendFrames :: Connection -> EncryptionLevel -> [Frame] -> IO ()

--- a/Network/QUIC/Connection.hs
+++ b/Network/QUIC/Connection.hs
@@ -166,6 +166,7 @@ module Network.QUIC.Connection (
   , Input(..)
   , Crypto(..)
   , Output(..)
+  , connAlive
   -- In this module
   , sendErrorCCFrame
   , sendCCFrameAndWait

--- a/Network/QUIC/Connection/Misc.hs
+++ b/Network/QUIC/Connection/Misc.hs
@@ -27,11 +27,11 @@ import Network.Socket
 import System.Mem.Weak
 
 import Network.QUIC.Connection.Queue
+import Network.QUIC.Connection.Timeout
 import Network.QUIC.Connection.Types
 import Network.QUIC.Connector
 import Network.QUIC.Imports
 import Network.QUIC.Parameters
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 ----------------------------------------------------------------
@@ -77,7 +77,7 @@ delayedAck :: Connection -> IO ()
 delayedAck conn@Connection{..} = do
     (oldcnt,send) <- atomicModifyIORef' delayedAckCount check
     when (oldcnt == 0) $ do
-        new <- cfire (Microseconds 20000) sendAck
+        new <- cfire conn (Microseconds 20000) sendAck
         join $ atomicModifyIORef' delayedAckCancel (new,)
     when send $ do
         let new = return ()

--- a/Network/QUIC/Connection/State.hs
+++ b/Network/QUIC/Connection/State.hs
@@ -6,7 +6,6 @@ module Network.QUIC.Connection.State (
   , setConnection1RTTReady
   , isConnectionEstablished
   , setConnectionEstablished
-  , setConnectionClosing
   , isCloseSent
   , setCloseSent
   , isCloseReceived
@@ -60,9 +59,6 @@ setConnection1RTTReady conn = do
 setConnectionEstablished :: Connection -> IO ()
 setConnectionEstablished conn = setConnectionState conn Established
 
-setConnectionClosing :: Connection -> IO ()
-setConnectionClosing conn = setConnectionState conn Closing
-
 ----------------------------------------------------------------
 
 isConnection1RTTReady :: Connection -> IO Bool
@@ -74,16 +70,12 @@ isConnection1RTTReady Connection{..} = atomically $ do
 
 setCloseSent :: Connection -> IO ()
 setCloseSent Connection{..} = do
-    atomically $ do
-        modifyTVar closeState $ \cs -> cs { closeSent = True }
-        writeTVar (connectionState connState) Closing
+    atomically $ modifyTVar closeState $ \cs -> cs { closeSent = True }
     writeIORef (sharedCloseSent shared) True
 
 setCloseReceived :: Connection -> IO ()
 setCloseReceived Connection{..} = do
-    atomically $ do
-        modifyTVar closeState $ \cs -> cs { closeReceived = True }
-        writeTVar (connectionState connState) Closing
+    atomically $ modifyTVar closeState $ \cs -> cs { closeReceived = True }
     writeIORef (sharedCloseReceived shared) True
 
 isCloseSent :: Connection -> IO Bool

--- a/Network/QUIC/Connection/Timeout.hs
+++ b/Network/QUIC/Connection/Timeout.hs
@@ -16,6 +16,7 @@ import GHC.Event
 import System.IO.Unsafe (unsafePerformIO)
 
 import Network.QUIC.Connection.Types
+import Network.QUIC.Connector
 import Network.QUIC.Imports
 import Network.QUIC.Types
 
@@ -47,7 +48,7 @@ fire conn (Microseconds microseconds) action = do
     void $ registerTimeout timmgr microseconds action'
   where
     action' = do
-        alive <- readIORef $ connAlive conn
+        alive <- getAlive conn
         when alive action `E.catch` ignore
 
 cfire :: Connection -> Microseconds -> TimeoutCallback -> IO (IO ())
@@ -58,7 +59,7 @@ cfire conn (Microseconds microseconds) action = do
     return cancel
   where
     action' = do
-        alive <- readIORef $ connAlive conn
+        alive <- getAlive conn
         when alive action `E.catch` ignore
 
 delay :: Microseconds -> IO ()

--- a/Network/QUIC/Connection/Timeout.hs
+++ b/Network/QUIC/Connection/Timeout.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
-module Network.QUIC.Timeout (
+module Network.QUIC.Connection.Timeout (
     timeouter
   , timeout
   , fire
@@ -15,6 +15,8 @@ import Data.Typeable
 import GHC.Event
 import System.IO.Unsafe (unsafePerformIO)
 
+import Network.QUIC.Connection.Types
+import Network.QUIC.Connector
 import Network.QUIC.Imports
 import Network.QUIC.Types
 
@@ -40,18 +42,25 @@ timeout (Microseconds microseconds) action = do
     E.handle (\TimeoutException -> return Nothing) $
         E.bracket setup cleanup $ \_ -> Just <$> action
 
-fire :: Microseconds -> TimeoutCallback -> IO ()
-fire (Microseconds microseconds) action = do
+fire :: Connection -> Microseconds -> TimeoutCallback -> IO ()
+fire conn (Microseconds microseconds) action = do
     timmgr <- getSystemTimerManager
-    void $ registerTimeout timmgr microseconds (action `E.catch` ignore)
+    void $ registerTimeout timmgr microseconds action'
+  where
+    action' = do
+        open <- isConnOpen conn
+        when open action `E.catch` ignore
 
-
-cfire :: Microseconds -> TimeoutCallback -> IO (IO ())
-cfire (Microseconds microseconds) action = do
+cfire :: Connection -> Microseconds -> TimeoutCallback -> IO (IO ())
+cfire conn (Microseconds microseconds) action = do
     timmgr <- getSystemTimerManager
-    key <- registerTimeout timmgr microseconds (action `E.catch` ignore)
+    key <- registerTimeout timmgr microseconds action'
     let cancel = unregisterTimeout timmgr key
     return cancel
+  where
+    action' = do
+        open <- isConnOpen conn
+        when open action `E.catch` ignore
 
 delay :: Microseconds -> IO ()
 delay (Microseconds microseconds) = threadDelay microseconds

--- a/Network/QUIC/Connection/Timeout.hs
+++ b/Network/QUIC/Connection/Timeout.hs
@@ -16,7 +16,6 @@ import GHC.Event
 import System.IO.Unsafe (unsafePerformIO)
 
 import Network.QUIC.Connection.Types
-import Network.QUIC.Connector
 import Network.QUIC.Imports
 import Network.QUIC.Types
 
@@ -48,8 +47,8 @@ fire conn (Microseconds microseconds) action = do
     void $ registerTimeout timmgr microseconds action'
   where
     action' = do
-        open <- isConnOpen conn
-        when open action `E.catch` ignore
+        alive <- readIORef $ connAlive conn
+        when alive action `E.catch` ignore
 
 cfire :: Connection -> Microseconds -> TimeoutCallback -> IO (IO ())
 cfire conn (Microseconds microseconds) action = do
@@ -59,8 +58,8 @@ cfire conn (Microseconds microseconds) action = do
     return cancel
   where
     action' = do
-        open <- isConnOpen conn
-        when open action `E.catch` ignore
+        alive <- readIORef $ connAlive conn
+        when alive action `E.catch` ignore
 
 delay :: Microseconds -> IO ()
 delay (Microseconds microseconds) = threadDelay microseconds

--- a/Network/QUIC/Connection/Types.hs
+++ b/Network/QUIC/Connection/Types.hs
@@ -216,6 +216,7 @@ data Connection = Connection {
   , connResources     :: IORef (IO ())
   -- Recovery
   , connLDCC          :: LDCC
+  , connAlive         :: IORef Bool
   }
 
 instance KeepQlog Connection where
@@ -294,6 +295,7 @@ newConnection rl myparams ver myAuthCIDs peerAuthCIDs debugLog qLog hooks sref =
         <*> newIORef (return ())
         -- Recovery
         <*> newLDCC connstate qLog put
+        <*> newIORef True
   where
     isclient = rl == Client
     initialRoleInfo

--- a/Network/QUIC/Connector.hs
+++ b/Network/QUIC/Connector.hs
@@ -20,6 +20,9 @@ data ConnState = ConnState {
   , packetNumber    :: IORef PacketNumber   -- squeezing three to one
   , encryptionLevel :: TVar EncryptionLevel -- to synchronize
   , maxPacketSize   :: IORef Int
+  -- Explicitly separated from 'ConnectionState'
+  -- It seems that STM triggers a dead-lock if
+  -- it is used in the close function of bracket.
   , connectionAlive :: IORef Bool
   }
 

--- a/Network/QUIC/Handshake.hs
+++ b/Network/QUIC/Handshake.hs
@@ -17,7 +17,6 @@ import Network.QUIC.Parameters
 import Network.QUIC.Qlog
 import Network.QUIC.Recovery
 import Network.QUIC.TLS
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 ----------------------------------------------------------------
@@ -165,7 +164,7 @@ handshakeServer' conf conn myAuthCIDs ver hsr = handshaker
     done ctx = do
         setEncryptionLevel conn RTT1Level
         TLS.getClientCertificateChain ctx >>= setCertificateChain conn
-        fire (Microseconds 100000) $ do
+        fire conn (Microseconds 100000) $ do
             let ldcc = connLDCC conn
             discarded0 <- getAndSetPacketNumberSpaceDiscarded ldcc RTT0Level
             unless discarded0 $ dropSecrets conn RTT0Level

--- a/Network/QUIC/IO.hs
+++ b/Network/QUIC/IO.hs
@@ -11,7 +11,6 @@ import Network.QUIC.Connector
 import Network.QUIC.Imports
 import Network.QUIC.Parameters
 import Network.QUIC.Stream
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 -- | Creating a bidirectional stream.
@@ -165,7 +164,7 @@ recvStream s n = do
     when (window <= (initialWindow .>>. 1)) $ do
         newMax <- addRxMaxStreamData s initialWindow
         sendFrames conn RTT1Level [MaxStreamData sid newMax]
-        fire (Microseconds 50000) $ do
+        fire conn (Microseconds 50000) $ do
             newMax' <- getRxMaxStreamData s
             sendFrames conn RTT1Level [MaxStreamData sid newMax']
     cwindow <- getRxDataWindow conn
@@ -173,7 +172,7 @@ recvStream s n = do
     when (cwindow <= (cinitialWindow .>>. 1)) $ do
         newMax <- addRxMaxData conn cinitialWindow
         sendFrames conn RTT1Level [MaxData newMax]
-        fire (Microseconds 50000) $ do
+        fire conn (Microseconds 50000) $ do
             newMax' <- getRxMaxData conn
             sendFrames conn RTT1Level [MaxData newMax']
     return bs

--- a/Network/QUIC/Receiver.hs
+++ b/Network/QUIC/Receiver.hs
@@ -21,7 +21,6 @@ import Network.QUIC.Parameters
 import Network.QUIC.Qlog
 import Network.QUIC.Recovery
 import Network.QUIC.Stream
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 receiver :: Connection -> Receive -> IO ()
@@ -303,7 +302,7 @@ processFrame conn lvl HandshakeDone
   | isServer conn || lvl /= RTT1Level =
         sendCCFrameAndBreak conn lvl ProtocolViolation "HANDSHAKE_DONE for server" 0x1e
   | otherwise = do
-        fire (Microseconds 100000) $ do
+        fire conn (Microseconds 100000) $ do
             let ldcc = connLDCC conn
             discarded0 <- getAndSetPacketNumberSpaceDiscarded ldcc RTT0Level
             unless discarded0 $ dropSecrets conn RTT0Level
@@ -315,7 +314,7 @@ processFrame conn lvl HandshakeDone
             clearCryptoStream conn RTT1Level
         setConnectionEstablished conn
         -- to receive NewSessionTicket
-        fire (Microseconds 1000000) $ killHandshaker conn lvl
+        fire conn (Microseconds 1000000) $ killHandshaker conn lvl
 processFrame conn lvl _ = sendCCFrameAndBreak conn lvl ProtocolViolation "Frame is not allowed" 0
 
 -- QUIC version 1 uses only short packets for stateless reset.

--- a/Network/QUIC/Recovery/Interface.hs
+++ b/Network/QUIC/Recovery/Interface.hs
@@ -18,7 +18,6 @@ import Network.QUIC.Recovery.Release
 import Network.QUIC.Recovery.Timer
 import Network.QUIC.Recovery.Types
 import Network.QUIC.Recovery.Utils
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 checkWindowOpenSTM :: LDCC -> Int -> STM ()

--- a/Network/QUIC/Recovery/Timer.hs
+++ b/Network/QUIC/Recovery/Timer.hs
@@ -25,7 +25,6 @@ import Network.QUIC.Recovery.Release
 import Network.QUIC.Recovery.Types
 import Network.QUIC.Recovery.Utils
 import Network.QUIC.Recovery.Constants
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 ----------------------------------------------------------------

--- a/Network/QUIC/Recovery/Timer.hs
+++ b/Network/QUIC/Recovery/Timer.hs
@@ -183,8 +183,8 @@ beforeAntiAmp ldcc = cancelLossDetectionTimer ldcc
 -- address validation.
 onLossDetectionTimeout :: LDCC -> IO ()
 onLossDetectionTimeout ldcc@LDCC{..} = do
-    open <- isConnOpen ldcc
-    when open $ do
+    alive <- getAlive ldcc
+    when alive $ do
         mtmi <- readIORef timerInfo
         case mtmi of
           Nothing -> return ()

--- a/Network/QUIC/Recovery/Types.hs
+++ b/Network/QUIC/Recovery/Types.hs
@@ -315,6 +315,7 @@ instance Connector LDCC where
     getMaxPacketSize   = readIORef  . maxPacketSize   . ldccState
     getConnectionState = readTVarIO . connectionState . ldccState
     getPacketNumber    = readIORef  . packetNumber    . ldccState
+    getAlive           = readIORef  . connectionAlive . ldccState
 
 ----------------------------------------------------------------
 

--- a/Network/QUIC/Recovery/Utils.hs
+++ b/Network/QUIC/Recovery/Utils.hs
@@ -9,8 +9,10 @@ module Network.QUIC.Recovery.Utils (
   , peerCompletedAddressValidation
   , countAckEli
   , inCongestionRecovery
+  , delay
   ) where
 
+import Control.Concurrent
 import Control.Concurrent.STM
 import Data.Sequence (Seq, (<|), ViewL(..))
 import qualified Data.Sequence as Seq
@@ -90,3 +92,8 @@ countAckEli sentPacket
 inCongestionRecovery :: TimeMicrosecond -> Maybe TimeMicrosecond -> Bool
 inCongestionRecovery _ Nothing = False
 inCongestionRecovery sentTime (Just crst) = sentTime <= crst
+
+----------------------------------------------------------------
+
+delay :: Microseconds -> IO ()
+delay (Microseconds microseconds) = threadDelay microseconds

--- a/Network/QUIC/Run.hs
+++ b/Network/QUIC/Run.hs
@@ -91,7 +91,10 @@ runClient conf client ver = do
           Right x -> return x
   where
     open = createClientConnection conf ver
-    clse = freeResources . connResConnection
+    clse connRes = do
+        let conn = connResConnection connRes
+        writeIORef (connAlive conn) False
+        freeResources conn
 
 createClientConnection :: ClientConfig -> Version -> IO ConnRes
 createClientConnection conf@ClientConfig{..} ver = do
@@ -178,7 +181,10 @@ runServer conf server dispatch mainThreadId acc = handleLogRun debugLog $
         runThreads
   where
     open = createServerConnection conf dispatch acc mainThreadId
-    clse = freeResources . connResConnection
+    clse connRes = do
+        let conn = connResConnection connRes
+        writeIORef (connAlive conn) False
+        freeResources conn
     debugLog msg = stdoutLogger ("runServer: " <> msg)
 
 createServerConnection :: ServerConfig -> Dispatch -> Accept -> ThreadId

--- a/Network/QUIC/Run.hs
+++ b/Network/QUIC/Run.hs
@@ -34,7 +34,6 @@ import Network.QUIC.Recovery
 import Network.QUIC.Sender
 import Network.QUIC.Server
 import Network.QUIC.Socket
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 ----------------------------------------------------------------

--- a/Network/QUIC/Run.hs
+++ b/Network/QUIC/Run.hs
@@ -93,7 +93,7 @@ runClient conf client ver = do
     open = createClientConnection conf ver
     clse connRes = do
         let conn = connResConnection connRes
-        writeIORef (connAlive conn) False
+        setDead conn
         freeResources conn
 
 createClientConnection :: ClientConfig -> Version -> IO ConnRes
@@ -183,7 +183,7 @@ runServer conf server dispatch mainThreadId acc = handleLogRun debugLog $
     open = createServerConnection conf dispatch acc mainThreadId
     clse connRes = do
         let conn = connResConnection connRes
-        writeIORef (connAlive conn) False
+        setDead conn
         freeResources conn
     debugLog msg = stdoutLogger ("runServer: " <> msg)
 

--- a/Network/QUIC/Server.hs
+++ b/Network/QUIC/Server.hs
@@ -232,8 +232,7 @@ dispatch Dispatch{..} ServerConfig{..}
               insertRecvQDict srcTable key q
               writeRecvQ q $ mkReceivedPacket cpkt tim bytes lvl
               let reg = registerConnectionDict dstTable
-                  unreg = \cid -> do
-                      fire (Microseconds 300000) $ unregisterConnectionDict dstTable cid
+                  unreg = unregisterConnectionDict dstTable
                   ent = Accept {
                       accVersion      = ver
                     , accMyAuthCIDs   = myAuthCIDs

--- a/Network/QUIC/Server.hs
+++ b/Network/QUIC/Server.hs
@@ -41,7 +41,6 @@ import Network.QUIC.Packet
 import Network.QUIC.Parameters
 import Network.QUIC.Qlog
 import Network.QUIC.Socket
-import Network.QUIC.Timeout
 import Network.QUIC.Types
 
 ----------------------------------------------------------------

--- a/quic.cabal
+++ b/quic.cabal
@@ -42,6 +42,7 @@ library
                        Network.QUIC.Connection.State
                        Network.QUIC.Connection.Stream
                        Network.QUIC.Connection.StreamTable
+                       Network.QUIC.Connection.Timeout
                        Network.QUIC.Connection.Types
                        Network.QUIC.Connector
                        Network.QUIC.Crypto
@@ -91,7 +92,6 @@ library
                        Network.QUIC.Stream.Table
                        Network.QUIC.Stream.Types
                        Network.QUIC.TLS
-                       Network.QUIC.Timeout
                        Network.QUIC.Types
                        Network.QUIC.Types.Ack
                        Network.QUIC.Types.CID

--- a/test/HandshakeSpec.hs
+++ b/test/HandshakeSpec.hs
@@ -110,11 +110,9 @@ testHandshake cc sc mode = void $ concurrently server client
     client = do
         threadDelay 10000
         runQUICClient cc $ \conn -> do
-            isConnectionOpen conn `shouldReturn` True
             waitEstablished conn
             handshakeMode <$> getConnectionInfo conn `shouldReturn` mode
     server = runQUICServer sc $ \conn -> do
-        isConnectionOpen conn `shouldReturn` True
         waitEstablished conn
         handshakeMode <$> getConnectionInfo conn `shouldReturn` mode
         stopQUICServer conn

--- a/test/TransportError.hs
+++ b/test/TransportError.hs
@@ -14,7 +14,7 @@ import System.Timeout
 import Test.Hspec
 
 import Network.QUIC
-import Network.QUIC.Internal
+import Network.QUIC.Internal hiding (timeout)
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Two problems:
- Leaking file descriptors
- CI fails without explicit reasons

`fire` is suspicious. Making `fire` so that it will not fire when the connection is dead.