### PR TITLE
Don't use x86-specific flags on aarch64

### DIFF
--- a/quic.cabal
+++ b/quic.cabal
@@ -138,7 +138,7 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall -Wcompat
   default-extensions:  Strict StrictData
-  if arch(x86_64) || arch(aarch64)
+  if arch(x86_64)
     cc-options:        -mavx2 -maes -mpclmul
     c-sources:         cbits/fusion.c cbits/picotls.c
 


### PR DESCRIPTION
See https://gcc.gnu.org/onlinedocs/gcc-11.2.0/gcc/x86-Options.html#x86-Options.
Example compilation failure on aarch64: https://hydra.nixos.org/build/155043506/nixlog/1