### PR TITLE
Chrome greasing

### DIFF
--- a/Network/QUIC/Receiver.hs
+++ b/Network/QUIC/Receiver.hs
@@ -183,7 +183,7 @@ processFrame :: Connection -> EncryptionLevel -> Frame -> IO ()
 processFrame _ _ Padding{} = return ()
 processFrame conn lvl Ping = do
     -- see ackEli above
-    when (lvl /= RTT1Level) $ sendFrames conn lvl []
+    when (lvl /= InitialLevel && lvl /= RTT1Level) $ sendFrames conn lvl []
 processFrame conn lvl (Ack ackInfo ackDelay) = do
     when (lvl == RTT0Level) $ closeConnection ProtocolViolation "ACK"
     onAckReceived (connLDCC conn) lvl ackInfo $ milliToMicro ackDelay

--- a/test/FrameSpec.hs
+++ b/test/FrameSpec.hs
@@ -46,3 +46,8 @@ spec = do
                 countZero (beg +. 1) (beg +. 10) `shouldReturn` 9
                 countZero (beg +. 1) (beg +. 11) `shouldReturn` 10
                 countZero (beg +. 2) (beg +. 3) `shouldReturn` 1
+                poke (beg +. 10) (1 :: Word8)
+                countZero beg end `shouldReturn` 10
+                countZero (beg +. 1) end `shouldReturn` 9
+                countZero (beg +. 2) end `shouldReturn` 8
+                countZero (beg +. 3) end `shouldReturn` 7


### PR DESCRIPTION
- Chrome Initial has a lot of greasing. For example, PING, PADDING, PING, CRYPTO, PING CRYPTO, PADDING, CRYPTO, ... This PING makes a Haskell server generate ACK packets and the three-times rule is fired. As workaround, we don't generate ACK in response to PING in Initial.
- Chrome ACK also has greasing like PADDING, PING, PADDING. This reveals a bug of `countZero`.
