### PR TITLE
commenting out gettimeofday which is not available on Windows.

### DIFF
--- a/cbits/picotls.c
+++ b/cbits/picotls.c
@@ -5300,9 +5300,13 @@ int (*volatile ptls_mem_equal)(const void *x, const void *y, size_t len) = mem_e
 
 static uint64_t get_time(ptls_get_time_t *self)
 {
+#if 0
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (uint64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+#else
+    return 0;
+#endif
 }
 
 ptls_get_time_t ptls_get_time = {get_time};


### PR DESCRIPTION
`get_time()` is not used in Haskell quic.

@BernardoGomesNegri #25 should be replaced with this PR. If something is missing, please add it based on this PR.

