### PR TITLE
add cabal flag for fusion support

### DIFF
--- a/quic.cabal
+++ b/quic.cabal
@@ -26,6 +26,11 @@ Flag devel
   Description:          Development commands
   Default:              False
 
+Flag fusion
+  Description:          Use fusion AES-GCM engine from picotls
+  Default:              True
+  Manual:               True
+
 ----------------------------------------------------------------
 
 library
@@ -147,7 +152,7 @@ library
   default-extensions:  Strict StrictData
   if os(windows)
     cc-options:        -D_WINDOWS
-  if arch(x86_64)
+  if flag(fusion) && arch(x86_64)
     cpp-options:       -DUSE_FUSION
     cc-options:        -mavx2 -maes -mpclmul
     c-sources:         cbits/fusion.c cbits/picotls.c


### PR DESCRIPTION
With the added flag, user can now choose to disable fusion support. It's now possible to compile for generic x86_64 platform (without AVX2).