### PR TITLE
build: bump unix-time requirements

### DIFF
--- a/quic.cabal
+++ b/quic.cabal
@@ -139,7 +139,7 @@ library
         stm >= 2.5 && < 2.6,
         data-default-class >= 0.1.2 && < 0.2,
         fast-logger >= 3.2.2 && < 3.3,
-        unix-time >= 0.4.11 && < 0.5,
+        unix-time >= 0.4.12 && < 0.5,
         iproute >= 1.7.12 && < 1.8,
         network >= 3.1.4 && < 3.2,
         network-byte-order >= 0.1.7 && < 0.2,


### PR DESCRIPTION
Closes #61

Note that a new package release is not required for this change because a new revision for `quic-0.1.16` is enough. However, [new revision on Hackage](https://github.com/haskell-infra/hackage-trustees/blob/master/revisions-information.md) requires manual editing of metadata.