### PR TITLE
fix syntax error, for GHC 9.2

### DIFF
--- a/Network/QUIC/Imports.hs
+++ b/Network/QUIC/Imports.hs
@@ -21,7 +21,7 @@ module Network.QUIC.Imports (
     module Network.ByteOrder,
     module Network.QUIC.Utils,
 #if !MIN_VERSION_base(4,17,0)
-  , (!<<.), (!>>.)
+    (!<<.), (!>>.),
 #endif
     atomicModifyIORef'',
     copyBS,


### PR DESCRIPTION
```
Network/QUIC/Imports.hs:24:3: error: parse error on input ‘,’
   |
24 |   , (!<<.), (!>>.)
   |   ^
```