### PR TITLE
data-default-class -> data-default

### DIFF
--- a/Network/QUIC/Config.hs
+++ b/Network/QUIC/Config.hs
@@ -3,7 +3,7 @@
 
 module Network.QUIC.Config where
 
-import Data.Default.Class
+import Data.Default
 import Data.IP
 import Network.Socket
 import Network.TLS hiding (Hooks, HostName, Version)

--- a/Network/QUIC/TLS.hs
+++ b/Network/QUIC/TLS.hs
@@ -7,7 +7,7 @@ module Network.QUIC.TLS (
 ) where
 
 import Control.Applicative ((<|>))
-import Data.Default.Class
+import Data.Default
 import Network.TLS hiding (Version)
 import Network.TLS.QUIC
 import System.X509

--- a/quic.cabal
+++ b/quic.cabal
@@ -140,7 +140,7 @@ library
         crypton-x509-system >= 1.6.7 && < 1.7,
         filepath >= 1.4 && < 1.6,
         stm >= 2.5 && < 2.6,
-        data-default-class >= 0.1.2 && < 0.2,
+        data-default >= 0.8 && <0.9,
         fast-logger >= 3.2.2 && < 3.3,
         unix-time >= 0.4.12 && < 0.5,
         iproute >= 1.7.12 && < 1.8,


### PR DESCRIPTION
data-default 0.8 deprecates data-default-class by moving the `Default` class from `Data.Default.Class` to `Data.Default`.

See: https://github.com/haskell-grpc-native/http2-client/pull/97
See: https://github.com/kazu-yamamoto/crypton-certificate/pull/11
See: https://github.com/haskell-tls/hs-tls/pull/486
See: https://github.com/commercialhaskell/stackage/issues/7545