### PR TITLE
compare the minimum packet size on packet size determination

### DIFF
--- a/Network/QUIC/Server/Run.hs
+++ b/Network/QUIC/Server/Run.hs
@@ -181,8 +181,14 @@ createServerConnection conf@ServerConfig{..} dispatch Accept{..} stvar = do
     initializeCoder conn InitialLevel $ initialSecrets ver cid
     setupCryptoStreams conn -- fixme: cleanup
     let peersa = accPeerSockAddr
+        -- RFC9000 \S14.2
+        -- "In the absence of these mechanisms, QUIC endpoints SHOULD
+        -- NOT send datagrams larger than the smallest allowed maximum
+        -- datagram size."
+        --
+        -- Thus use 1200 bytes for minimum packet size.
         pktSiz =
-            (defaultPacketSize peersa `max` accPacketSize)
+            (defaultQUICPacketSize `max` accPacketSize)
                 `min` maximumPacketSize peersa
     setMaxPacketSize conn pktSiz
     setInitialCongestionWindow (connLDCC conn) pktSiz


### PR DESCRIPTION
when we compare the packet size configured either with 1) ccPacketSize (ClientConfig) or 2) accPacketSize (received pkt size at a server), it compared with defaultQUICPacketSize, which is 1350 or 1330 (ipv6 or ipv4).  As a result, we cannot configure ccPacketSize less than that value.

This commit fixes to use defaultQUICPacketSize, 1200, which is the smallest allowed maximum datagram size defined in RFC9000, to allow to configure ccPacketSize less than 1350/1300 bytes.