### PR TITLE
Fix `recvStream` overflow on pending data

### DIFF
--- a/Network/QUIC/IO.hs
+++ b/Network/QUIC/IO.hs
@@ -180,7 +180,11 @@ acceptStream conn = do
 
 -- | Receiving data in the stream. In the case where a FIN is received
 --   an empty bytestring is returned.
-recvStream :: Stream -> Int -> IO ByteString
+recvStream
+    :: Stream
+    -> Int -- ^ Number of bytes to receive. In certain cases, `recvStream` can return
+           -- fewer bytes than requested, but never more bytes than requested..
+    -> IO ByteString
 recvStream s n = do
     bs <- takeRecvStreamQwithSize s n
     let len = BS.length bs


### PR DESCRIPTION
This change fixes an issue when there is data pending in a Stream queue.

When asking for `n` bytes in the stream, the function `takeRecvStreamQwithSize` would behave very differently whether there was data pending in the queue, or not. This would cause the `recvStream` function to return more than `n` bytes, causing all sorts of strange troubles downstream.

Now, `recvStream n stream` will *always* return `n` bytes or fewer.

Fixes #83 